### PR TITLE
fix(roagen): fix clone condition

### DIFF
--- a/modules/roagen.nix
+++ b/modules/roagen.nix
@@ -32,7 +32,7 @@ in
         set -e
 
         cd /tmp
-        if [ -e registry ]; then
+        if [ ! -e registry ]; then
           git clone --depth=1 https://git.dn42.dev/dn42/registry.git
           cd registry
         else


### PR DESCRIPTION
I think only when there’s no dn42 registry locally, we clone a new one.