### PR TITLE
libDn42: init with mkPeer functions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
       };
 
       libDn42 = {
-        inherit (import ./lib/dn42.nix { inherit (nixpkgs) lib; }) mkPeerV4 mkPeerV6;
+        inherit (import ./lib/dn42.nix { inherit (nixpkgs) lib; }) mkPeerV4 mkPeerV6 mkCollector6;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
         dn42 = {
           imports = [ ./modules ];
           nixpkgs.overlays = [ self.overlays.default ];
+          _module.args = { inherit (self) libDn42; };
         };
         default = dn42;
       };
@@ -54,6 +55,10 @@
           };
         };
         default = dn42;
+      };
+
+      libDn42 = {
+        inherit (import ./lib/dn42.nix { inherit (nixpkgs) lib; }) mkPeerV4 mkPeerV6;
       };
     };
 }

--- a/lib/dn42.nix
+++ b/lib/dn42.nix
@@ -96,4 +96,40 @@ in
         source address ${ownIp};
       }
     '';
+  mkCollector6 =
+    {
+      ownAs,
+      remoteAs ? 4242422602,
+      ownIp,
+      remoteIp ? "fd42:4242:2601:ac12::1",
+    }:
+    ''
+      protocol bgp collector_6 {
+        ${template ownAs}
+
+        neighbor ${remoteIp} as ${toString remoteAs};
+        source address ${ownIp};
+
+        # enable multihop as the collector is not locally connected
+        multihop;
+
+        ipv4 {
+          # export all available paths to the collector
+          add paths tx;
+
+          # import/export filters
+          import none;
+          export where dn_export_collector4();
+        };
+
+        ipv6 {
+          # export all available paths to the collector
+          add paths tx;
+
+          # import/export filters
+          import none;
+          export where dn_export_collector6();
+        };
+      }
+    '';
 }

--- a/lib/dn42.nix
+++ b/lib/dn42.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  ...
+}:
+let
+  template = ownAs: ''
+    local as ${toString ownAs};
+
+    enforce first as on;
+    graceful restart on;
+    long lived graceful restart on;
+    advertise hostname on;
+    prefer older on;
+
+    # defaults
+    enable route refresh on;
+    interpret communities on;
+    default bgp_local_pref 100;
+  '';
+in
+{
+  mkPeerV4 =
+    {
+      name,
+      ownAs,
+      remoteAs,
+      ownIp,
+      remoteIp,
+
+      # bgp communities
+      latency,
+      bandwidth,
+      crypto,
+      transit,
+    }:
+    ''
+      protocol bgp ${name}_4 {
+        ${template ownAs}
+
+        neighbor ${remoteIp} as ${builtins.toString remoteAs};
+        source address ${ownIp};
+
+        ipv4 {
+          import limit 9000 action block;
+          import table on;
+
+          import where dn_import_filter4(${toString latency}, ${toString bandwidth}, ${toString crypto});
+          export where dn_export_filter4(${toString latency}, ${toString bandwidth}, ${toString crypto}, ${lib.boolToString transit});
+        };
+      }
+    '';
+  mkPeerV6 =
+    {
+      name,
+      ownAs,
+      remoteAs,
+      ownIp,
+      remoteIp,
+      ownInterface,
+
+      # bgp communities
+      latency,
+      bandwidth,
+      crypto,
+      transit,
+
+      # whether ipv4 session should be configured for the ipv6 neighbor
+      extendedNextHop,
+    }:
+    ''
+      protocol bgp ${name}_6 {
+        ${template ownAs}
+
+        ${lib.optionalString extendedNextHop ''
+          enable extended messages on;
+
+          ipv4 {
+            import limit 9000 action block;
+            import table on;
+
+            extended next hop on;
+            import where dn_import_filter4(${toString latency}, ${toString bandwidth}, ${toString crypto});
+            export where dn_export_filter4(${toString latency}, ${toString bandwidth}, ${toString crypto}, ${lib.boolToString transit});
+          };
+        ''}
+
+        ipv6 {
+          import limit 9000 action block;
+          import table on;
+
+          import where dn_import_filter6(${toString latency}, ${toString bandwidth}, ${toString crypto});
+          export where dn_export_filter6(${toString latency}, ${toString bandwidth}, ${toString crypto}, ${lib.boolToString transit});
+        };
+
+        neighbor ${remoteIp}%'${ownInterface}' as ${toString remoteAs};
+        source address ${ownIp};
+      }
+    '';
+}

--- a/modules/bird2.nix
+++ b/modules/bird2.nix
@@ -155,44 +155,10 @@ in
             '')
           cfg.peers))}
 
-        protocol bgp collector_6 from dnpeers {
-          local as ${builtins.toString cfg.as};
-
-          enforce first as on;
-          graceful restart on;
-          long lived graceful restart on;
-          advertise hostname on;
-          prefer older on;
-
-          # defaults
-          enable route refresh on;
-          interpret communities on;
-          default bgp_local_pref 100;
-
-          neighbor fd42:4242:2601:ac12::1 as 4242422602;
-          source address ${cfg.addr.v6};
-
-          # enable multihop as the collector is not locally connected
-          multihop;
-
-          ipv4 {
-            # export all available paths to the collector    
-            add paths tx;
-
-            # import/export filters
-            import none;
-            export where dn_export_collector4();
-          };
-
-          ipv6 {
-            # export all available paths to the collector    
-            add paths tx;
-
-            # import/export filters
-            import none;
-            export where dn_export_collector6();
-          };
-        }
+        ${libDn42.mkCollector6 {
+          ownAs = cfg.as;
+          ownIp = cfg.addr.v6;
+        }}
       '';
     };
   };


### PR DESCRIPTION
This pull request introduced a library of functions to create an ipv4 / ipv6 peer, in preparation for a rewrite of this module to allow the addition of dn42 peers to an existing bird instance